### PR TITLE
Increase SCP timeout

### DIFF
--- a/scp_uploader.py
+++ b/scp_uploader.py
@@ -123,7 +123,7 @@ class SCPUploader(BaseUploader):
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         data = dict(username=self.username, port=int(self.port),
-                    timeout=5.0)
+                    timeout=150)
 
         if self.keyfile:
             private_key = os.path.expanduser(self.keyfile)
@@ -135,7 +135,7 @@ class SCPUploader(BaseUploader):
 
         self.ssh.connect(self.host, **data)
         self.client = SCPClient(self.ssh.get_transport(),
-                                progress=self.ssh_progress)
+                                progress=self.ssh_progress, socket_timeout=15)
 
     def upload_file(self, filename):
         try:


### PR DESCRIPTION
When uploading large files, the process fails with a _timeout exception_:

```
Traceback (most recent call last):
  File "/home/nico/miniconda2/envs/py36/lib/python3.6/site-packages/scp_uploader.py", line 142, in upload_file
    self.client.put(filename, remote_path=self.remote_dir)
  File "/home/nico/miniconda2/envs/py36/lib/python3.6/site-packages/scp.py", line 166, in put
    self._send_files(files)
  File "/home/nico/miniconda2/envs/py36/lib/python3.6/site-packages/scp.py", line 271, in _send_files
    self._send_file(fl, name, mode, size)
  File "/home/nico/miniconda2/envs/py36/lib/python3.6/site-packages/scp.py", line 297, in _send_file
    self._recv_confirm()
  File "/home/nico/miniconda2/envs/py36/lib/python3.6/site-packages/scp.py", line 358, in _recv_confirm
    raise SCPException('Timeout waiting for scp response')
scp.SCPException: Timeout waiting for scp response
```

This patch fixes that by increasing default timeouts during initialization of SCP libraries.