### PR TITLE
Fix attribute error when upload fails

### DIFF
--- a/scp_uploader.py
+++ b/scp_uploader.py
@@ -147,7 +147,7 @@ class SCPUploader(BaseUploader):
         except Exception as err:
             log.error('Failed to upload file')
             log.debug(err, exc_info=True)
-            self._connect()
+            self.connect()
             return False
 
     def ssh_progress(self, filename, size, sent):


### PR DESCRIPTION
`self._connect()` doesn't exist, I assume it was a typo and `self.connect()` was intended. I'm not really sure why it is being called here, perhaps the intention is to get an error message from scp?